### PR TITLE
Improve building

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,12 +1,15 @@
 import argparse
 import os
 import subprocess
+import multiprocessing
 
 DEBUG_BUILD_DIR = "llvm-project/build_debug"
 RELEASE_BUILD_DIR = "llvm-project/build_release"
 LIBP2_DIR = "libp2"
 LIBP2PP_DIR = "libp2++"
 LIBC_DIR = "libc"
+
+CPU_COUNT = multiprocessing.cpu_count()
 
 build_dir = ""
 
@@ -30,8 +33,8 @@ def build_llvm(configure=True, debug=False, install_dest=None):
     os.makedirs(build_dir, exist_ok=True)
 
     # setup cmake command
-    cmake_cmd = [   'cmake', 
-                    '-G', 
+    cmake_cmd = [   'cmake',
+                    '-G',
                     'Unix Makefiles',
 		            '-DCMAKE_OSX_ARCHITECTURES=arm64',
                     '-DLLVM_INSTALL_UTILS=true'
@@ -57,9 +60,9 @@ def build_llvm(configure=True, debug=False, install_dest=None):
 
     # build LLVM, optionally installing it
     if (install_dest):
-        subprocess.run(['make', 'install', '-j32'], cwd=build_dir, check=True)
+        subprocess.run(['make', 'install', f'-j{CPU_COUNT}'], cwd=build_dir, check=True)
     else:
-        subprocess.run(['make', '-j32'], cwd=build_dir, check=True)
+        subprocess.run(['make', f'-j{CPU_COUNT}'], cwd=build_dir, check=True)
 
     # install the linker script to either the install destination or the build directory
     if (install_dest):
@@ -89,7 +92,7 @@ def build_libp2(install_dest, llvm, clean=False, configure=True):
     if clean:
         subprocess.run(['make', 'clean'], cwd=build_dir, check=True)
 
-    llvm_cmd = ['make', f'LLVM={llvm}', '-j32']
+    llvm_cmd = ['make', f'LLVM={llvm}', f'-j{CPU_COUNT}']
     subprocess.run(llvm_cmd, cwd=build_dir, check=True)
 
     # install libp2
@@ -119,7 +122,7 @@ def build_libp2pp(install_dest, llvm, clean=False, configure=True):
     if clean:
         subprocess.run(['make', 'clean'], cwd=build_dir, check=True)
 
-    subprocess.run(['make', f'LLVM={llvm}', '-j32'], cwd=build_dir, check=True)
+    subprocess.run(['make', f'LLVM={llvm}', f'-j{CPU_COUNT}'], cwd=build_dir, check=True)
 
     # install libp2
     install_dir = os.path.join(install_dest, "libp2")
@@ -146,7 +149,7 @@ def build_libc(install_dest, llvm, clean=False, configure=True):
     if clean:
         subprocess.run(['make', 'clean'], cwd=build_dir, check=True)
 
-    subprocess.run(['make', f'LLVM={llvm}', '-j32'], cwd=build_dir, check=True)
+    subprocess.run(['make', f'LLVM={llvm}', f'-j{CPU_COUNT}'], cwd=build_dir, check=True)
     # install libc
     install_dir = os.path.join(install_dest, "libc")
     os.makedirs(os.path.join(install_dir, 'lib'), exist_ok=True)
@@ -170,7 +173,7 @@ def main():
     parser.add_argument('--clean', nargs='?', const=True, default=False)
     parser.add_argument('--debug', nargs='?', const=True, default=False)
     parser.add_argument('--install', type=str, required=False)
-    
+
     args = parser.parse_args()
 
     configure = args.configure

--- a/build.py
+++ b/build.py
@@ -17,10 +17,7 @@ def copy(src, dst, cwd=None, recurse=False):
 
     cmd += [src, dst]
 
-    p = subprocess.Popen(cmd, cwd=cwd)
-    p.wait()
-    if p.returncode != 0:
-        return False
+    subprocess.run(cmd, cwd=cwd, check=True)
 
     return True
 
@@ -56,22 +53,13 @@ def build_llvm(configure=True, debug=False, install_dest=None):
 
     # run cmake
     if (configure):
-        p = subprocess.Popen(cmake_cmd, cwd=build_dir)
-        p.wait()
-
-        if p.returncode != 0:
-            return False
+        subprocess.run(cmake_cmd, cwd=build_dir, check=True)
 
     # build LLVM, optionally installing it
     if (install_dest):
-        p = subprocess.Popen(['make', 'install', '-j32'], cwd=build_dir)
+        subprocess.run(['make', 'install', '-j32'], cwd=build_dir, check=True)
     else:
-        p = subprocess.Popen(['make', '-j32'], cwd=build_dir)
-
-    p.wait()
-
-    if p.returncode != 0:
-        return False
+        subprocess.run(['make', '-j32'], cwd=build_dir, check=True)
 
     # install the linker script to either the install destination or the build directory
     if (install_dest):
@@ -96,23 +84,13 @@ def build_libp2(install_dest, llvm, clean=False, configure=True):
     if configure:
         cmake_cmd = ['cmake', '-Dllvm=' + str(os.path.join(install_dest, 'bin')), '../']
 
-        p = subprocess.Popen(cmake_cmd, cwd=build_dir)
-        p.wait()
-
-        if p.returncode != 0:
-            return False
-        
+        subprocess.run(cmake_cmd, cwd=build_dir, check=True)
 
     if clean:
-        p = subprocess.Popen(['make', 'clean'], cwd=build_dir)
-        p.wait()
-        if p.returncode != 0:
-            return False
+        subprocess.run(['make', 'clean'], cwd=build_dir, check=True)
 
-    p = subprocess.Popen(['make', 'LLVM=' + llvm, '-j8'], cwd=build_dir)
-    p.wait()
-    if p.returncode != 0:
-        return False
+    llvm_cmd = ['make', f'LLVM={llvm}', '-j32']
+    subprocess.run(llvm_cmd, cwd=build_dir, check=True)
 
     # install libp2
     install_dir = os.path.join(install_dest, "libp2")
@@ -136,24 +114,12 @@ def build_libp2pp(install_dest, llvm, clean=False, configure=True):
     # build libp2++
     if configure:
         cmake_cmd = ['cmake', '-Dllvm=' + str(os.path.join(install_dest, 'bin')), '../']
-
-        p = subprocess.Popen(cmake_cmd, cwd=build_dir)
-        p.wait()
-
-        if p.returncode != 0:
-            return False
-        
+        subprocess.run(cmake_cmd, cwd=build_dir, check=True)
 
     if clean:
-        p = subprocess.Popen(['make', 'clean'], cwd=build_dir)
-        p.wait()
-        if p.returncode != 0:
-            return False
+        subprocess.run(['make', 'clean'], cwd=build_dir, check=True)
 
-    p = subprocess.Popen(['make', 'LLVM=' + llvm, '-j8'], cwd=build_dir)
-    p.wait()
-    if p.returncode != 0:
-        return False
+    subprocess.run(['make', f'LLVM={llvm}', '-j32'], cwd=build_dir, check=True)
 
     # install libp2
     install_dir = os.path.join(install_dest, "libp2")
@@ -175,24 +141,12 @@ def build_libc(install_dest, llvm, clean=False, configure=True):
     if configure:
         cmake_cmd = ['cmake', '-Dllvm=' + str(os.path.join(install_dest, 'bin')), '../']
 
-        p = subprocess.Popen(cmake_cmd, cwd=build_dir)
-        p.wait()
-
-        if p.returncode != 0:
-            return False
-        
+        subprocess.run(cmake_cmd, cwd=build_dir, check=True)
 
     if clean:
-        p = subprocess.Popen(['make', 'clean'], cwd=build_dir)
-        p.wait()
-        if p.returncode != 0:
-            return False
+        subprocess.run(['make', 'clean'], cwd=build_dir, check=True)
 
-    p = subprocess.Popen(['make', 'LLVM=' + llvm, '-j8'], cwd=build_dir)
-    p.wait()
-    if p.returncode != 0:
-        return False
-
+    subprocess.run(['make', f'LLVM={llvm}', '-j32'], cwd=build_dir, check=True)
     # install libc
     install_dir = os.path.join(install_dest, "libc")
     os.makedirs(os.path.join(install_dir, 'lib'), exist_ok=True)

--- a/build.py
+++ b/build.py
@@ -21,7 +21,7 @@ def logged_run(*a, **kw):
         logging.debug(f'CWD: {kw["cwd"]}')
     if len(a) == 1 and isinstance(a[0], list):
         logging.debug(f'CMD: {" ".join(a[0])}')
-    subprocess.run(*a, **kw)
+    return subprocess.run(*a, **kw)
 
 
 def copy(src, dst, cwd=None, recurse=False):

--- a/libp2/lib/builtins/powf.c
+++ b/libp2/lib/builtins/powf.c
@@ -1,8 +1,6 @@
 #define SINGLE_PRECISION
 #include "fp_lib.h"
 
-#include "math.h"
-
 extern fp_t __powf(fp_t a, fp_t _b);
 
 COMPILER_RT_ABI fp_t powf(fp_t a, fp_t b) {

--- a/libp2/lib/builtins/sqrtf.c
+++ b/libp2/lib/builtins/sqrtf.c
@@ -1,8 +1,6 @@
 #define SINGLE_PRECISION
 #include "fp_lib.h"
 
-#include <stdio.h>
-
 static const fp_t one = 1.0, tiny=1.0e-30;
 
 fp_t __attribute__ ((noinline)) __sqrtf(fp_t x) {
@@ -13,7 +11,7 @@ fp_t __attribute__ ((noinline)) __sqrtf(fp_t x) {
     fp_t z;
 	int32_t s,q,m,t,i;
 	uint32_t r;
-    
+
     // handle Inf/NaN
     if (exp == maxExponent) {
         if (ix & signBit) return 0.0f/0.0f; // -Inf or NaN, return NaN
@@ -46,12 +44,12 @@ fp_t __attribute__ ((noinline)) __sqrtf(fp_t x) {
 	r = 0x01000000;		/* r = moving bit from right to left */
 
 	while(r!=0) {
-	    t = s+r; 
-	    if(t<=ix) { 
-		s    = t+r; 
-		ix  -= t; 
-		q   += r; 
-	    } 
+	    t = s+r;
+	    if(t<=ix) {
+		s    = t+r;
+		ix  -= t;
+		q   += r;
+	    }
 	    ix += ix;
 	    r>>=1;
 	}


### PR DESCRIPTION
This PR just adds a couple of quality of life things. 

First, by consequently using subprocess.run with check=True, failing commands terminate the process. Some failures have been silently swallowed before, creating confusion.

And then the CPU_COUNT in -j was a bit all over the place, cleaned that up and use multiprocessing.cpu_count so it tailors to the build host.